### PR TITLE
Kind of fixed the "crooked" lines.

### DIFF
--- a/src/power-flow-card.ts
+++ b/src/power-flow-card.ts
@@ -634,7 +634,7 @@ export class PowerFlowCard extends LitElement {
                     d="M${hasBattery ? 55 : 53},0 v${hasGrid
                       ? 15
                       : 17} c0,${hasBattery
-                      ? "35 10,30 30,30"
+                      ? "30 10,30 30,30"
                       : "40 10,35 30,35"} h25"
                     vector-effect="non-scaling-stroke"
                   ></path>
@@ -674,7 +674,7 @@ export class PowerFlowCard extends LitElement {
                     id="return"
                     class="return"
                     d="M${hasBattery ? 45 : 47},0 v15 c0,${hasBattery
-                      ? "35 -10,30 -30,30"
+                      ? "30 -10,30 -30,30"
                       : "40 -10,35 -30,35"} h-20"
                     vector-effect="non-scaling-stroke"
                   ></path>
@@ -793,7 +793,7 @@ export class PowerFlowCard extends LitElement {
                   <path
                     id="battery-home"
                     class="battery-home"
-                    d="M55,100 v-${hasGrid ? 15 : 17} c0,-35 10,-30 30,-30 h20"
+                    d="M55,100 v-${hasGrid ? 15 : 17} c0,-30 10,-30 30,-30 h20"
                     vector-effect="non-scaling-stroke"
                   ></path>
                   ${batteryConsumption
@@ -834,7 +834,7 @@ export class PowerFlowCard extends LitElement {
                       "battery-from-grid": Boolean(batteryFromGrid),
                       "battery-to-grid": Boolean(batteryToGrid),
                     })}
-                    d="M45,100 v-15 c0,-35 -10,-30 -30,-30 h-20"
+                    d="M45,100 v-15 c0,-30 -10,-30 -30,-30 h-20"
                     vector-effect="non-scaling-stroke"
                   ></path>
                   ${batteryFromGrid

--- a/src/power-flow-card.ts
+++ b/src/power-flow-card.ts
@@ -635,7 +635,7 @@ export class PowerFlowCard extends LitElement {
                       ? 15
                       : 17} c0,${hasBattery
                       ? "30 10,30 30,30"
-                      : "40 10,35 30,35"} h25"
+                      : "35 10,35 30,35"} h25"
                     vector-effect="non-scaling-stroke"
                   ></path>
                   ${solarConsumption
@@ -675,7 +675,7 @@ export class PowerFlowCard extends LitElement {
                     class="return"
                     d="M${hasBattery ? 45 : 47},0 v15 c0,${hasBattery
                       ? "30 -10,30 -30,30"
-                      : "40 -10,35 -30,35"} h-20"
+                      : "35 -10,35 -30,35"} h-20"
                     vector-effect="non-scaling-stroke"
                   ></path>
                   ${solarToGrid && hasSolarProduction


### PR DESCRIPTION
I must admit, I have no real clue of what I'm doing. Haven't used much Github before. The last time I used version control software was in university, about 20 years ago :-D 

So, I forked your fork of the power-flow-card and changed some of the paths that create the lines. I always thought the lines in the original energy dashboard where somewhat "crooked". I do think it looks a little better now. 

I hope creating this pull request is the way to do things. Let me know if that's not how it's done.

Here is a before and after.

![2023-03-24 20_39_54-Übersicht – Home Assistant](https://user-images.githubusercontent.com/37976738/227635639-216da605-dac7-4e42-9e43-96328a195003.png)

![2023-03-24 20_48_07-Übersicht – Home Assistant](https://user-images.githubusercontent.com/37976738/227635665-9629098b-bc3b-4172-896a-bcb547899946.png)
